### PR TITLE
Initial code

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,2 @@
+// Package httperr provides Go errors which encapsulate HTTP response codes.
+package httperr

--- a/httperr.go
+++ b/httperr.go
@@ -1,0 +1,69 @@
+package httperr
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+// statusCoder is the main interface to errors in this package.
+type statusCoder interface {
+	StatusCode() int
+}
+
+// causer is a local version of github.com/pkg/errors.causer
+type causer interface {
+	Cause() error
+}
+
+// stackTracer is a local version of github.com/pkg/errors.stackTracer
+type stackTracer interface {
+	StackTrace() errors.StackTrace
+}
+
+// withStatus wraps a standard error and an HTTP status code.
+type withStatus struct {
+	error
+	status int
+	*stack
+}
+
+var _ error = &withStatus{}
+var _ statusCoder = &withStatus{}
+var _ causer = &withStatus{}
+var _ stackTracer = &withStatus{}
+
+func (e *withStatus) Cause() error {
+	return e.error
+}
+
+func (e *withStatus) StatusCode() int {
+	return e.status
+}
+
+// New returns a new error message, tied to the provided HTTP status code.
+func New(status int, msg string) error {
+	return &withStatus{
+		error:  errors.New(msg),
+		status: status,
+		stack:  callers(),
+	}
+}
+
+// Errorf returns a new error message, tied to the provided HTTP status code.
+func Errorf(status int, format string, args ...interface{}) error {
+	return &withStatus{
+		error:  fmt.Errorf(format, args...),
+		status: status,
+		stack:  callers(),
+	}
+}
+
+// WithStatus wraps an existing error with the provided HTTP status code.
+func WithStatus(status int, err error) error {
+	return &withStatus{
+		error:  err,
+		status: status,
+		stack:  callers(),
+	}
+}

--- a/stack.go
+++ b/stack.go
@@ -1,0 +1,42 @@
+package httperr
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/pkg/errors"
+)
+
+/* The contents of this file is borrowed from github.com/pkg/errors */
+
+// stack represents a stack of program counters.
+type stack []uintptr
+
+func (s *stack) Format(st fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case st.Flag('+'):
+			for _, pc := range *s {
+				f := errors.Frame(pc)
+				fmt.Fprintf(st, "\n%+v", f)
+			}
+		}
+	}
+}
+
+func (s *stack) StackTrace() errors.StackTrace {
+	f := make([]errors.Frame, len(*s))
+	for i := 0; i < len(f); i++ {
+		f[i] = errors.Frame((*s)[i])
+	}
+	return f
+}
+
+func callers() *stack {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(3, pcs[:])
+	var st stack = pcs[0:n]
+	return &st
+}


### PR DESCRIPTION
This is the basic 'errors' functionality from our httperr package.

I'm interested in feedback on whether anything should be changed as we separate this functionality from Desk, as it's a good opportunity to rename things (I've done a little renaming already), or changing other functionality slightly.

This leaves in our Desk-only httperr, some helper functions (which are mostly obsolete (i.e. `JSONString`), and our error handler, which doesn't make senes to include in this package.