### PR TITLE
Ensure that formatting works

### DIFF
--- a/httperr.go
+++ b/httperr.go
@@ -35,6 +35,9 @@ var _ stackTracer = &withStatus{}
 
 func (e *withStatus) Cause() error    { return e.error }
 func (e *withStatus) StatusCode() int { return e.status }
+func (e withStatus) Format(s fmt.State, verb rune) {
+	fmt.Fprintf(s, "%v (%v)", e.error, e.status)
+}
 
 // New returns a new error message with stack trace, tied to the provided HTTP
 // status code.
@@ -100,6 +103,10 @@ var _ causer = &wrapped{}
 func (e *wrapped) Error() string   { return e.msg }
 func (e *wrapped) Cause() error    { return e.error }
 func (e *wrapped) StatusCode() int { return e.status }
+
+func (e wrapped) Format(s fmt.State, verb rune) {
+	fmt.Fprintf(s, "%v (%v)", e.error, e.status)
+}
 
 // Wrap returns an error annotating err with a stack trace, HTTP status code,
 // and the supplied message. If err is nil, Wrap returns nil.

--- a/httperr.go
+++ b/httperr.go
@@ -36,7 +36,7 @@ var _ stackTracer = &withStatus{}
 func (e *withStatus) Cause() error    { return e.error }
 func (e *withStatus) StatusCode() int { return e.status }
 func (e withStatus) Format(s fmt.State, verb rune) {
-	fmt.Fprintf(s, "%v (%v)", e.error, e.status)
+	fmt.Fprintf(s, "%v", e.error)
 }
 
 // New returns a new error message with stack trace, tied to the provided HTTP
@@ -105,7 +105,7 @@ func (e *wrapped) Cause() error    { return e.error }
 func (e *wrapped) StatusCode() int { return e.status }
 
 func (e wrapped) Format(s fmt.State, verb rune) {
-	fmt.Fprintf(s, "%v (%v)", e.error, e.status)
+	fmt.Fprintf(s, "%v", e.error)
 }
 
 // Wrap returns an error annotating err with a stack trace, HTTP status code,

--- a/httperr_test.go
+++ b/httperr_test.go
@@ -1,0 +1,91 @@
+package httperr
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestFormatWithStatus(t *testing.T) {
+	cases := []struct {
+		in   withStatus
+		fmt  string
+		want string
+	}{
+		{
+			withStatus{
+				error:  errors.New("oh noes"),
+				status: 42,
+			},
+			"%v",
+			"oh noes (42)",
+		},
+		{
+			withStatus{
+				error:  errors.New("oh noes"),
+				status: 42,
+			},
+			"%#v",
+			"oh noes (42)",
+		},
+		{
+			withStatus{
+				error:  errors.New("oh noes"),
+				status: 42,
+			},
+			"%s",
+			"oh noes (42)",
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+			out := fmt.Sprintf(tc.fmt, tc.in)
+			if out != tc.want {
+				t.Errorf("\nout:  %#v\nwant: %#v\n", out, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatWrapped(t *testing.T) {
+	cases := []struct {
+		in   wrapped
+		fmt  string
+		want string
+	}{
+		{
+			wrapped{
+				error:  errors.New("oh noes"),
+				status: 42,
+			},
+			"%v",
+			"oh noes (42)",
+		},
+		{
+			wrapped{
+				error:  errors.New("oh noes"),
+				status: 42,
+			},
+			"%#v",
+			"oh noes (42)",
+		},
+		{
+			wrapped{
+				error:  errors.New("oh noes"),
+				status: 42,
+			},
+			"%s",
+			"oh noes (42)",
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+			out := fmt.Sprintf(tc.fmt, tc.in)
+			if out != tc.want {
+				t.Errorf("\nout:  %#v\nwant: %#v\n", out, tc.want)
+			}
+		})
+	}
+}

--- a/httperr_test.go
+++ b/httperr_test.go
@@ -18,7 +18,7 @@ func TestFormatWithStatus(t *testing.T) {
 				status: 42,
 			},
 			"%v",
-			"oh noes (42)",
+			"oh noes",
 		},
 		{
 			withStatus{
@@ -26,7 +26,7 @@ func TestFormatWithStatus(t *testing.T) {
 				status: 42,
 			},
 			"%#v",
-			"oh noes (42)",
+			"oh noes",
 		},
 		{
 			withStatus{
@@ -34,7 +34,7 @@ func TestFormatWithStatus(t *testing.T) {
 				status: 42,
 			},
 			"%s",
-			"oh noes (42)",
+			"oh noes",
 		},
 	}
 
@@ -60,7 +60,7 @@ func TestFormatWrapped(t *testing.T) {
 				status: 42,
 			},
 			"%v",
-			"oh noes (42)",
+			"oh noes",
 		},
 		{
 			wrapped{
@@ -68,7 +68,7 @@ func TestFormatWrapped(t *testing.T) {
 				status: 42,
 			},
 			"%#v",
-			"oh noes (42)",
+			"oh noes",
 		},
 		{
 			wrapped{
@@ -76,7 +76,7 @@ func TestFormatWrapped(t *testing.T) {
 				status: 42,
 			},
 			"%s",
-			"oh noes (42)",
+			"oh noes",
 		},
 	}
 

--- a/public.go
+++ b/public.go
@@ -18,7 +18,7 @@ var _ causer = &publicError{}
 func (e *publicError) Error() string { return e.msg }
 func (e *publicError) Cause() error  { return e.err }
 
-func (e *publicError) Format(s fmt.State, verb rune) {
+func (e publicError) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 'v':
 		if s.Flag('+') {

--- a/public_test.go
+++ b/public_test.go
@@ -1,0 +1,100 @@
+package httperr
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestFormatPublicError(t *testing.T) {
+	cases := []struct {
+		in   publicError
+		fmt  string
+		want string
+	}{
+		{
+			publicError{
+				err: errors.New("oh noes"),
+				msg: "public",
+			},
+			"%v",
+			"public",
+		},
+		{
+			publicError{
+				err: errors.New("oh noes"),
+				msg: "public",
+			},
+			"%#v",
+			"public",
+		},
+		{
+			publicError{
+				err: errors.New("oh noes"),
+				msg: "public",
+			},
+			"%s",
+			"public",
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+			out := fmt.Sprintf(tc.fmt, tc.in)
+			if out != tc.want {
+				t.Errorf("\nout:  %#v\nwant: %#v\n", out, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatPublicWithStatus(t *testing.T) {
+	cases := []struct {
+		in   publicWithStatus
+		fmt  string
+		want string
+	}{
+		{
+			publicWithStatus{
+				status: 42,
+				publicError: publicError{
+					err: errors.New("oh noes"),
+					msg: "public",
+				},
+			},
+			"%v",
+			"public",
+		},
+		{
+			publicWithStatus{
+				status: 42,
+				publicError: publicError{
+					err: errors.New("oh noes"),
+					msg: "public",
+				},
+			},
+			"%#v",
+			"public",
+		},
+		{
+			publicWithStatus{
+				status: 42,
+				publicError: publicError{
+					err: errors.New("oh noes"),
+					msg: "public",
+				},
+			},
+			"%s",
+			"public",
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+			out := fmt.Sprintf(tc.fmt, tc.in)
+			if out != tc.want {
+				t.Errorf("\nout:  %#v\nwant: %#v\n", out, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We're currently losing error information because it doesn't. One example
(of many) is: https://sentry.io/teamwork/desk/issues/350338423/

which is printed as:

	return errors.Errorf("cannot find Customer: %v", err)

And `err` is `*httperr.withStatus`.